### PR TITLE
Support coproducts in graphtraversal

### DIFF
--- a/lca_algebraic/lca.py
+++ b/lca_algebraic/lca.py
@@ -465,11 +465,7 @@ def actToExpression(act: Activity, extract_activities=None):
 
                 act_expr = rec_func(sub_act, exch_in_path)
 
-            avoidedBurden = 1
-            if exch['type'] == 'production' and not exch['input'] == exch['output']:
-                avoidedBurden = -1
-                
-            res += formula * act_expr * avoidedBurden 
+            res += formula * act_expr
 
         return res / outputAmount
 

--- a/lca_algebraic/lca.py
+++ b/lca_algebraic/lca.py
@@ -465,7 +465,11 @@ def actToExpression(act: Activity, extract_activities=None):
 
                 act_expr = rec_func(sub_act, exch_in_path)
 
-            res += formula * act_expr
+            avoidedBurden = 1
+            if exch['type'] == 'production' and not exch['input'] == exch['output']:
+                avoidedBurden = -1
+                
+            res += formula * act_expr * avoidedBurden
 
         return res / outputAmount
 

--- a/lca_algebraic/lca.py
+++ b/lca_algebraic/lca.py
@@ -465,7 +465,11 @@ def actToExpression(act: Activity, extract_activities=None):
 
                 act_expr = rec_func(sub_act, exch_in_path)
 
-            res += formula * act_expr
+            avoidedBurden = 1
+            if exch['type'] == 'production' and not exch['input'] == exch['output']:
+                avoidedBurden = -1
+                
+            res += formula * act_expr * avoidedBurden 
 
         return res / outputAmount
 


### PR DESCRIPTION
Brightway2 activities can have exchanges of type "production" to refer to the products they produce. 
It's often associated with tag for "reference product" e.g. in the activity browser.

When an activity has several exchanges of type "production" it means that the activity is producing several products, the reference ones, and others defined in another activity.

bw2 LCA calculations supports this, and performs substitutions on the co-products, as long as the database / technosphere matrix is well-defined (i.e. square)

For lca_algebraic to support this, in the graph traversal, we need to check if the exchange is of type production and not referring to the current activity. 

Use case:

```
YieldBiochar = newFloatParam('y_bc',
                            default=0.25, min=0.18, max=0.30,
                            description='Biochar yield, in kg dry per kg dry biomass')

eibiomass = getActByCode('ecoinvent 3.5', '9b997b399076f62b40b72a85648f8fbe')

activity1 = newActivity(USER_DB, 
    "heat production", 
    "megajoule", 
    exchanges= { },
    code='soup-heat') 
activity1.addExchanges({activity1 :  1})

activity2 = newActivity(USER_DB, 
    "biochar production",
    "kilogram", 
    exchanges= {},
    code='mop-biochar' )
                    
activity2.addExchanges({activity2 : {'amount':1}}) # type = production for that exchange, because input is self
activity2.addExchanges({activity1 : {'amount': 234.94 * exp(-6.56*YieldBiochar) , 'type':'production'}}) # coproduct

activity3 = newActivity(USER_DB, 
    "biomass production", 
    "kilogram", 
    exchanges= { },
    code='soup-biomass' )
activity3.addExchanges({activity3: {'amount':1}})
activity3.addExchanges({eibiomass:1})

activity1.addExchanges({activity3 : {'amount':1/20}})
activity2.addExchanges({activity3 : {'amount':1/YieldBiochar}})

printAct(activity1) 
printAct(activity2)
printAct(activity3)

impacts = [m for m in bw.methods if 'ILCD 1.0.8 2016' in str(m) and 'no LT' in str(m)]
```

with bw2 function
```
multiLCA(
    activity2, 
    [impacts[1]],                    
    # Parameters of the model
    y_bc=0.15
)
```
 
with lca_algebraic function
```
multiLCAAlgebric(
    activity2, 
    [impacts[1]], 
    # Parameters of the model
    y_bc=0.15
)
```

Now yield the same results.