### PR TITLE
stats.py

### DIFF
--- a/lca_algebraic/stats.py
+++ b/lca_algebraic/stats.py
@@ -491,7 +491,7 @@ def _incer_stochastic_violin(methods, Y, figsize=(15, 15), figspace=(0.5, 0.5), 
 
         ax.violinplot(data, showmedians=True)
         ax.title.set_text(method_name(method))
-        ax.set_ylim(ymin=0)
+        #ax.set_ylim(ymin=0)
         ax.set_ylabel(method_unit(method))
         ax.set_xticklabels([])
 


### PR DESCRIPTION
changed the violin plot to not start from 0 because if ylim is not adapted it is hard to see the violin plot for categories with big absolute impacts.