### PR TITLE
Fix the storage of formula to not colapse with brightway formula

### DIFF
--- a/lca_algebraic/activity.py
+++ b/lca_algebraic/activity.py
@@ -24,6 +24,7 @@ from lca_algebraic.params import (
     _complete_and_expand_params,
     _getAmountOrFormula,
     _param_registry,
+    STORE_FORMULA_KEY
 )
 
 from .base_utils import ValueOrExpression, getActByCode
@@ -35,7 +36,6 @@ from .units import unit_registry as u
 # Can be used in expression of amount for updateExchanges, in order to reference the previous value
 old_amount = symbols("old_amount")
 old_amount_with_unit = u.Quantity(old_amount, u.old_unit)
-
 
 def _exch_name(exch):
     return exch["name"] if "name" in exch else str(exch.input)
@@ -285,7 +285,7 @@ class ActivityExtended(Activity):
                 if not str(symbol) in all_symbols:
                     raise Exception("Symbol '%s' not found in params : %s" % (symbol, all_symbols))
 
-            res["formula"] = str(amount)
+            res[STORE_FORMULA_KEY] = str(amount)
             res["amount"] = 0
         elif isinstance(amount, float) or isinstance(amount, int):
             res["amount"] = amount

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -30,7 +30,7 @@ from .units import unit_registry as u
 
 DEFAULT_PARAM_GROUP = "acv"
 UNCERTAINTY_TYPE = "uncertainty type"
-
+STORE_FORMULA_KEY = "lca_algebraic_formula"
 
 class ParamType:
     """Type of parameters"""
@@ -1246,12 +1246,12 @@ def _parse_formula(formula):
 
 def _getAmountOrFormula(ex: ExchangeDataset) -> Union[Basic, float]:
     """Return either a fixed float value or an expression for the amount of this exchange"""
-    if "formula" in ex:
+    if STORE_FORMULA_KEY in ex:
         try:
             # We don't want support for units there
-            return _parse_formula(ex["formula"])
+            return _parse_formula(ex[STORE_FORMULA_KEY])
         except Exception as e:
-            warn(f"Error '{e}' while parsing formula {ex['formula']} : backing to amount")
+            warn(f"Error '{e}' while parsing formula {ex[STORE_FORMULA_KEY]} : backing to amount")
 
     return ex["amount"]
 


### PR DESCRIPTION
In the current version of lca_algebraic formula are stored inplace of brightway formula which cause errors when using ecoinvent 3.10+ database. The patch fix this issue by storing lca_algebraic formula with it's own key.