### PR TITLE
oat_matrix and incer_stochastic_matrix return the data

### DIFF
--- a/lca_algebraic/stats.py
+++ b/lca_algebraic/stats.py
@@ -155,6 +155,7 @@ def oat_matrix(
     )
     _heatmap(change.transpose(), title, 100, ints=True)
 
+    return change
 
 def _oat_dasboard(
     model,
@@ -471,6 +472,8 @@ def incer_stochastic_matrix(model, methods, functional_unit=1, n=DEFAULT_N, name
     sob = _sobols(methods, problem, Y)
 
     _incer_stochastic_matrix(methods, problem["names"], Y, sob, name_type=name_type)
+
+    return sob
 
 
 def _incer_stochastic_violin(methods, Y, figsize=(15, 15), figspace=(0.5, 0.5), sharex=True, nb_cols=3):


### PR DESCRIPTION
In the stats.py file, the functions oat_matrix and incer_stochastic_matrix only plot results without returning the data that becomes inaccessible to the user of the package. Therefore, in this pull request we added a return of the data used for plotting. We do not expect any breaking change as the functions did not return anything before.