### PR TITLE
Fix and improve interpolate with units

### DIFF
--- a/lca_algebraic/interpolation.py
+++ b/lca_algebraic/interpolation.py
@@ -51,10 +51,14 @@ def interpolate_activities(
     param:
         Parameter controlling the interpolation
     act_per_value:
-        Dictionnary of value => activitiy [Dict]
+        Dictionnary of value => Activitiy [Dict]
+        Notes: 
+            * Acticity may be None, it's equivalent to an activity without exchanges.
+            * If parameter is lower than the lowest bound in act_per_value then this activity is equal to to the activity at lower bound
+            * If parameter is higher than the highest bound in act_per_value then this activity is equal to to the activity at highest bound
 
     add_zero:
-        If True add the "Zero" point to the data.
+        If True add the "Zero" point to the data, i.e. add act_per_value[0.0] = None
         Useful for linear interpolation of a single activity / point
 
     Returns

--- a/lca_algebraic/interpolation.py
+++ b/lca_algebraic/interpolation.py
@@ -83,8 +83,14 @@ def interpolate_activities(
     act_per_value = act_per_value.copy()
 
     if add_zero:
-        # Trick to keep the unit.
         act_per_value[0.0 * next(iter(act_per_value))] = None
+
+    # Find unit
+    units = [act["unit"] for act in act_per_value.values() if act is not None]
+    same_unit = all(x == units[0] for x in units)
+
+    if not same_unit:
+        warn("Warning : units of activities should be the same : %s" % str(units))
 
     # List of segments : triplet of (start, end, expression)
     segments = defaultdict(list)
@@ -100,7 +106,7 @@ def interpolate_activities(
         if l_act == r_act:
             unit_amount = 1.0
             if Settings.units_enabled:
-                unit_amount |= parse_db_unit(l_act["unit"])
+                unit_amount |= parse_db_unit(units[0])
             segments[l_act].append([l_val, r_val, unit_amount])
             continue
 
@@ -119,12 +125,6 @@ def interpolate_activities(
     if Settings.units_enabled:
         exchanges = {act: amount|parse_db_unit(act["unit"]) for act, amount in exchanges.items()}
 
-    # Find unit
-    units = list(act["unit"] for act in exchanges.keys())
-    same_unit = all(x == units[0] for x in units)
-
-    if not same_unit:
-        warn("Warning : units of activities should be the same : %s" % str(units))
 
     # Create act
     new_act = newActivity(db_name=db_name, name=act_name, unit=units[0], exchanges=exchanges)

--- a/lca_algebraic/interpolation.py
+++ b/lca_algebraic/interpolation.py
@@ -4,11 +4,18 @@ from typing import Dict
 from sympy import Piecewise, simplify
 
 from lca_algebraic import ParamDef, newActivity, warn
+import pint
 
+from .units import parse_db_unit
+from .settings import Settings
 
-def _segments_to_piecewise(param, segments):
+def _segments_to_piecewise(act, param, segments):
     conds = []
     for start, end, val in segments:
+        val = act._transform_unit(val, act["unit"])
+        # BUG ? Cannot store quantity in Piecewise.
+        if isinstance(val, pint.Quantity):
+            val = val.m
         cond = True
         if start is not None:
             cond = cond & (param >= start)
@@ -101,7 +108,10 @@ def interpolate_activities(
         )  # Will equal 0 at current point and 1 at next point
 
     # Transform segments into piecewize expressions
-    exchanges = {act: _segments_to_piecewise(param, segs) for act, segs in segments.items() if act is not None}
+    exchanges = {act: _segments_to_piecewise(act, param, segs) for act, segs in segments.items() if act is not None}
+
+    if Settings.units_enabled:
+        exchanges = {act: amount|parse_db_unit(act["unit"]) for act, amount in exchanges.items()}
 
     # Find unit
     units = list(act["unit"] for act in exchanges.keys())

--- a/lca_algebraic/interpolation.py
+++ b/lca_algebraic/interpolation.py
@@ -83,7 +83,8 @@ def interpolate_activities(
     act_per_value = act_per_value.copy()
 
     if add_zero:
-        act_per_value[0.0] = None
+        # Trick to keep the unit.
+        act_per_value[0.0 * next(iter(act_per_value))] = None
 
     # List of segments : triplet of (start, end, expression)
     segments = defaultdict(list)

--- a/lca_algebraic/interpolation.py
+++ b/lca_algebraic/interpolation.py
@@ -85,26 +85,27 @@ def interpolate_activities(
     segments = defaultdict(list)
 
     # Transform to sorted list of value => activity
-    sorted_points = sorted(act_per_value.items(), key=lambda item: item[0])
-    for i, (curr_val, curr_act) in enumerate(sorted_points):
-        if i >= len(sorted_points) - 1:
-            continue
-
-        # Next val and act
-        next_val, next_act = sorted_points[i + 1]
-
-        # Boundaries of segment : none if first / last point
-        start = curr_val if i > 0 else None
-        end = next_val if i < (len(sorted_points) - 2) else None
+    sorted_points = list(sorted(act_per_value.items(), key=lambda item: item[0]))
+    sorted_points = [(None, sorted_points[0][1])]+sorted_points+[(None, sorted_points[-1][1])]
+    for (l_val, l_act), (r_val, r_act) in zip(sorted_points[0:-1],sorted_points[1:]):
 
         # Add segment for current activity
-        segments[curr_act].append(
-            [start, end, (param - next_val) / (curr_val - next_val)]
+
+        # Left bound, right bound or same activity on left or right
+        if l_act == r_act:
+            unit_amount = 1.0
+            if Settings.units_enabled:
+                unit_amount |= parse_db_unit(l_act["unit"])
+            segments[l_act].append([l_val, r_val, unit_amount])
+            continue
+
+        segments[l_act].append(
+            [l_val, r_val, (param - r_val) / (l_val - r_val)]
         )  # Will equal 1 at current point and 0 at next point
 
         # Add segment for next activity
-        segments[next_act].append(
-            [start, end, (param - curr_val) / (next_val - curr_val)]
+        segments[r_act].append(
+            [l_val, r_val, (param - l_val) / (r_val - l_val)]
         )  # Will equal 0 at current point and 1 at next point
 
     # Transform segments into piecewize expressions

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -380,26 +380,39 @@ def test_interpolation(data):
     # Common helper to check results
     def check_impacts(model, p_values, expected_results):
         # Compute impacts for several values of p
-        impacts = compute_impacts(model, [data.ibio1], p=p_values)
-
-        values = impacts[impacts.columns[0]]
-        assert_array_equal(values, expected_results)
+        methods = list(expected_results)
+        impacts = compute_impacts(model, methods, p=p_values)
+        print(impacts)
+        for i, k in enumerate(methods):
+            values = impacts.iloc[:,i]
+            assert_array_equal(values, expected_results[k])
 
     # Define param
     p = newFloatParam("p", 1.0, min=1, max=3)
 
     # Create act1 act2 and act4 having respectively 1.0, 2.0 units of bio1
-    act1, act2 = [newActivity(USER_DB, "act%d" % v, "unit", {data.bio1: v}) for v in [1.0, 2.0]]
+    act1 = newActivity(USER_DB, "act1", "unit", {data.bio1: 1.0})
+    act2 = newActivity(USER_DB, "act2", "unit", {data.bio2: 1.0})
 
     # Interpolate between 1 : act1 (1 bio1) and 3 : act2 (2 bio1)
     interp1 = interpolate_activities(USER_DB, "interp1", p, {1.0: act1, 3.0: act2})
 
-    check_impacts(interp1, [0.0, 1.0, 2.0, 3.0, 5.0], [0.5, 1.0, 1.5, 2.0, 3.0])
+    check_impacts(interp1,
+                    [0.0, 1.0, 2.0, 3.0, 4.0],
+    {
+        data.ibio1: [1.0, 1.0,  .5, 0.0, 0.0],
+        data.ibio2: [0.0, 0.0,  .5, 1.0, 1.0],
+    })
 
     # Interpolate including zero
-    interp_with_zero = interpolate_activities(USER_DB, "interp_w_zero", p, {1.0: act1, 3.0: act2}, add_zero=True)
+    interp_with_zero = interpolate_activities(USER_DB, "interp_with_zero", p, {1.0: act1, 3.0: act2}, add_zero=True)
 
-    check_impacts(interp_with_zero, [0.0, 0.5, 1.0, 3.0], [0.0, 0.5, 1.0, 2.0])
+    check_impacts(interp_with_zero,
+                    [0.0, 1.0, 2.0, 3.0, 4.0],
+    {
+        data.ibio1: [0.0, 1.0,  .5, 0.0, 0.0],
+        data.ibio2: [0.0, 0.0,  .5, 1.0, 1.0],
+    })
 
 
 def test_user_function(data):


### PR DESCRIPTION
Hello,

This patch fix the handle of units using lca_algebraic.interpolate_activities. Actually Piecewise seems to not work with pint.Quantity, thus the patch remove unit during the Piecewise creation and put it back afterward.

Anothe improvement is about the creation of the Peicewise that have redondant/overlaping ranges. For instance:

Witt the following interpolate activity:

```
return agb.interpolate_activities(
    db_name = conf.target_database,
    act_name = ACTIVITY_NAME,
    param=conf.inverter_power_capacity,
    act_per_value={
        0.0 | u.kW : inverter_2500W_per_kg,
        2.5 | u.kW : inverter_2500W_per_kg,
        500.0 | u.kW : inverter_500kW_per_kg,
        1e30 | u.kW : inverter_500kW_per_kg
    }
)
```

Before the patch, I get following Piecewise, with overlapping lower-bounds and upper-bound.
```
(1.0 - 0.4*inverter_power_capacity, inverter_power_capacity < 2.5)
(0.4*inverter_power_capacity, inverter_power_capacity < 2.5)
(1.00502512562814 - 0.00201005025125628*inverter_power_capacity, (inverter_power_capacity >= 2.5) & (inverter_power_capacity < 500.0))
'[parasol] inverter production, 500kW per kg' (kg, GLO, None) kg
(0.00201005025125628*inverter_power_capacity - 0.0050251256281407, (inverter_power_capacity >= 2.5) & (inverter_power_capacity < 500.0))
(1.0 - 1.0e-30*inverter_power_capacity, inverter_power_capacity >= 500.0)
(1.0e-30*inverter_power_capacity - 5.0e-28, inverter_power_capacity >= 500.0)
```


After the patch, all piece does not overlap the first and last segment are the same of the first and the last activity respectively.
```
'[parasol] inverter production, 2.5kW per kg' (kg, GLO, None) kg
(1.0, inverter_power_capacity < 0)
(1.0, (inverter_power_capacity < 2.5) & (inverter_power_capacity >= 0))
(1.00502512562814 - 0.00201005025125628*inverter_power_capacity, (inverter_power_capacity >= 2.5) & (inverter_power_capacity < 500.0))
'[parasol] inverter production, 500kW per kg' (kg, GLO, None) kg
(0.00201005025125628*inverter_power_capacity - 0.0050251256281407, (inverter_power_capacity >= 2.5) & (inverter_power_capacity < 500.0))
(1.0, (inverter_power_capacity >= 500.0) & (inverter_power_capacity < 1.0e+30))
(1.0, inverter_power_capacity >= 1.0e+30)
```
