### PR TITLE
Switch evaluation order for unit coherency check

### DIFF
--- a/lca_algebraic/activity.py
+++ b/lca_algebraic/activity.py
@@ -298,7 +298,7 @@ class ActivityExtended(Activity):
             new_amount = amount.to(target_unit).magnitude
 
             # Auto scale disabld ?
-            if not _equals(amount.magnitude, new_amount) and not u.auto_scale:
+            if not u.auto_scale and not _equals(amount.magnitude, new_amount):
                 raise Exception(f"auto_scale is disabled. '{amount}' should be explicity transformed to {target_unit}")
 
             return new_amount


### PR DESCRIPTION
_equals can take a long time to compute with a long of variables while u.auto_scale is always inexpensive.
Avoid testing the equality when u.auto_scale is True.