### PR TITLE
Improve stats.oat_matrix

### DIFF
--- a/lca_algebraic/stats.py
+++ b/lca_algebraic/stats.py
@@ -110,6 +110,7 @@ def oat_matrix(
     n=10,
     title="Impact variability (% of mean)",
     name_type=NameType.LABEL,
+    oat_parameters : set|list|None = None,
     override_defaults_values=dict()
 ):
     """
@@ -128,6 +129,10 @@ def oat_matrix(
     functional_unit:
         Float value of expression by which to divide each impact.
 
+    oat_parameters:
+        list or set to select parameters on which to perform OAT, all
+        parameters are selected if oat_parameters is None. default: None
+
     override_defaults_values:
         this is a dictionnary of (parameter name, value) that will override
         the parameter defaults value. This allow to perform OAT with different
@@ -139,6 +144,14 @@ def oat_matrix(
 
     # Sort params by category
     sorted_params = _extract_var_params(lambdas)
+
+    if oat_parameters is not None:
+        if isinstance(oat_parameters, list):
+            oat_parameters = set(oat_parameters)
+
+        if not isinstance(oat_parameters, list|set):
+            raise Exception(f"Invalid oat_parameters, should be list or set got: `{type(oat_parameters)}`")
+        sorted_params = [p for p in sorted_params if p.name in oat_parameters]
 
     change = np.zeros((len(sorted_params), len(impacts)))
 

--- a/lca_algebraic/stats.py
+++ b/lca_algebraic/stats.py
@@ -110,6 +110,7 @@ def oat_matrix(
     n=10,
     title="Impact variability (% of mean)",
     name_type=NameType.LABEL,
+    override_defaults_values=dict()
 ):
     """
 
@@ -126,6 +127,11 @@ def oat_matrix(
 
     functional_unit:
         Float value of expression by which to divide each impact.
+
+    override_defaults_values:
+        this is a dictionnary of (parameter name, value) that will override
+        the parameter defaults value. This allow to perform OAT with different
+        defaults values.
     """
 
     # Compile model into lambda functions for fast LCA
@@ -136,8 +142,11 @@ def oat_matrix(
 
     change = np.zeros((len(sorted_params), len(impacts)))
 
+    defaults_params = {param.name: param.default for param in sorted_params}
+    defaults_params.update(override_defaults_values)
+
     for iparam, param in enumerate(sorted_params):
-        params = {param.name: param.default for param in sorted_params}
+        params = defaults_params.copy()
 
         # Compute range of values for given param
         params[param.name] = param.range(n)

--- a/lca_algebraic/stats.py
+++ b/lca_algebraic/stats.py
@@ -158,6 +158,8 @@ def oat_matrix(
     defaults_params = {param.name: param.default for param in sorted_params}
     defaults_params.update(override_defaults_values)
 
+    df_ref = _postMultiLCAAlgebric(impacts, lambdas, **defaults_params)
+
     for iparam, param in enumerate(sorted_params):
         params = defaults_params.copy()
 
@@ -168,7 +170,7 @@ def oat_matrix(
         df = _postMultiLCAAlgebric(impacts, lambdas, **params)
 
         # Compute change
-        change[iparam] = (df.max() - df.min()) / df.median() * 100
+        change[iparam] = (df.max() - df.min()) / df_ref * 100
 
     # Build final heatmap
     change = pd.DataFrame(


### PR DESCRIPTION
This patch series add:
* a filter to which parameters to compute in stas.oat_matrix
* an option to override defaults values of parameters

This patch series changes:
* the reference value used to compute the relative change, it's use the result using defaults inputs.