### PR TITLE
Fix ParamRegistry.__getitem__ to not add empty item

### DIFF
--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -899,9 +899,9 @@ class ParamRegistry:
 
     def __getitem__(self, key):
         try:
-            params_per_db = self.params[key]
+            params_per_db = self.params.get(key, None)
 
-            if len(params_per_db) == 0:
+            if params_per_db is None:
                 # Param not found
                 raise KeyError("Parameter %s not found" % key)
 


### PR DESCRIPTION
ParamRegistry.__getitem__ unconditionally add item key to self.params. This patch fix it

Fix: #57 