### PR TITLE
Fix sympy assumptions

### DIFF
--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -694,6 +694,8 @@ def loadParams(global_variable=True, dbname=None):
         first_enum_param = list(param_values.values())[0]
         args = _loadArgs(first_enum_param)
         del args["default"]
+        del args["min"]
+        del args["max"]
 
         # Dictionary of enum values with scale as weight
         args["values"] = {key: data["scale"] for key, data in param_values.items()}

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, List, Union
 
+import math
 import numpy as np
 import pandas as pd
 from bw2data.parameters import (
@@ -153,7 +154,26 @@ class ParamDef(Symbol):
         if len(user_assumptions) != 0:
             assumptions = user_assumptions
         else:
+
+            vmin = kwargs.get("min", None)
+            if vmin is None:
+                vmin = -math.inf
+
+            vmax = kwargs.get("max", None)
+            if vmax is None:
+                vmax = +math.inf
+
             assumptions = {"real": True}
+
+            if vmin > 0.0:
+                assumptions = {"positive": True}
+            elif vmin >= 0.0:
+                assumptions = {"nonnegative": True}
+
+            if vmax < 0.0:
+                assumptions = {"negative": True}
+            elif vmax <= 0.0:
+                assumptions = {"nonpositive": True}
 
         # To avoid name collision we add a dbname assumption
         if (dbname := kwargs.get("dbname", None)) is not None:

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -133,13 +133,31 @@ class ParamDef(Symbol):
     Don't instantiate it directly. Use the function **newXXXParam() instead.
     """
 
-    def __new__(cls, name, *karg, **kargs):
-        # We use dbname as an "assumption" so that two symbols with same name are not equal if from separate DBs
-        assumptions = dict()
-        assumptions["real"] = True
+    def __new__(cls, name, *args, **kwargs):
 
-        if "dbname" in kargs and kargs["dbname"]:
-            assumptions[kargs["dbname"]] = True
+        # list of documented assumptions here:
+        # https://docs.sympy.org/latest/guides/assumptions.html#predicates
+        valid_assumptions = {
+            'algebraic', 'commutative', 'complex', 'extended_negative',
+            'extended_nonnegative', 'extended_nonpositive', 'extended_nonzero',
+            'extended_positive', 'extended_real', 'finite', 'hermitian',
+            'imaginary', 'infinite', 'integer', 'irrational', 'negative',
+            'noninteger', 'nonnegative', 'nonpositive', 'nonzero', 'positive',
+            'rational', 'real', 'transcendental', 'zero'
+        }
+
+        # filter args keeping only valid assumptions
+        user_assumptions = {k: v for k, v in kwargs.items() if k in valid_assumptions}
+
+        # Select user assumptions if provided
+        if len(user_assumptions) != 0:
+            assumptions = user_assumptions
+        else:
+            assumptions = {"real": True}
+
+        # To avoid name collision we add a dbname assumption
+        if (dbname := kwargs.get("dbname", None)) is not None:
+            assumptions[dbname] = True
 
         return Symbol.__new__(cls, name, **assumptions)
 

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -685,6 +685,8 @@ def loadParams(global_variable=True, dbname=None):
         first_enum_param = list(param_values.values())[0]
         args = _loadArgs(first_enum_param)
         del args["default"]
+        del args["min"]
+        del args["max"]
 
         # Dictionary of enum values with scale as weight
         args["values"] = {key: data["scale"] for key, data in param_values.items()}

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -15,6 +15,8 @@ from IPython.core.display import HTML
 from pint import Quantity
 from scipy.stats import beta, lognorm, norm, triang, truncnorm
 from sympy import Basic, Expr, Symbol, parse_expr
+from sympy.core.assumptions import _assume_defined
+
 from tabulate import tabulate
 
 from lca_algebraic.axis_dict import AxisDict
@@ -133,13 +135,20 @@ class ParamDef(Symbol):
     Don't instantiate it directly. Use the function **newXXXParam() instead.
     """
 
-    def __new__(cls, name, *karg, **kargs):
-        # We use dbname as an "assumption" so that two symbols with same name are not equal if from separate DBs
-        assumptions = dict()
-        assumptions["real"] = True
+    def __new__(cls, name, *args, **kwargs):
 
-        if "dbname" in kargs and kargs["dbname"]:
-            assumptions[kargs["dbname"]] = True
+        # filter args keeping only valid assumptions
+        user_assumptions = {k: v for k, v in kwargs.items() if k in _assume_defined}
+
+        # Select user assumptions if provided
+        if len(user_assumptions) != 0:
+            assumptions = user_assumptions
+        else:
+            assumptions = {"real": True}
+
+        # To avoid name collision we add a dbname assumption
+        if (dbname := kwargs.get("dbname", None)) is not None:
+            assumptions[dbname] = True
 
         return Symbol.__new__(cls, name, **assumptions)
 

--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, List, Union
 
+import math
 import numpy as np
 import pandas as pd
 from bw2data.parameters import (
@@ -144,7 +145,26 @@ class ParamDef(Symbol):
         if len(user_assumptions) != 0:
             assumptions = user_assumptions
         else:
+
+            vmin = kwargs.get("min", None)
+            if vmin is None:
+                vmin = -math.inf
+
+            vmax = kwargs.get("max", None)
+            if vmax is None:
+                vmax = +math.inf
+
             assumptions = {"real": True}
+
+            if vmin > 0.0:
+                assumptions = {"positive": True}
+            elif vmin >= 0.0:
+                assumptions = {"nonnegative": True}
+
+            if vmax < 0.0:
+                assumptions = {"negative": True}
+            elif vmax <= 0.0:
+                assumptions = {"nonpositive": True}
 
         # To avoid name collision we add a dbname assumption
         if (dbname := kwargs.get("dbname", None)) is not None:

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -284,6 +284,50 @@ def test_simplify_model(data):
     assert res.expr.__repr__() == "3.0*p5 + 6.01"
 
 
+def test_params_user_assumptions(subtests):
+    from lca_algebraic import newFloatParam
+
+    # commented out assumptions that will be inconsistant, for instance
+    # 'real' is inconsistant with 'imaginary'
+    assumptions = {
+        'algebraic',
+        'commutative',
+        'complex',
+        'extended_negative',
+        'extended_nonnegative',
+        'extended_nonpositive',
+        'extended_nonzero',
+        'extended_positive',
+        'extended_real',
+        'finite',
+        'hermitian',
+        'imaginary',
+        'infinite',
+        'integer',
+        'irrational',
+        'negative',
+        'noninteger',
+        'nonnegative',
+        'nonpositive',
+        'nonzero',
+        'positive',
+        'rational',
+        'real',
+        'transcendental',
+        'zero'
+    }
+
+    def test(a):
+        p1 = newFloatParam(f"{a}_true",  default=1.0, **{a: True})
+        p2 = newFloatParam(f"{a}_false", default=1.0, **{a: False})
+        assert p1.assumptions0[a] is True
+        assert p2.assumptions0[a] is False
+
+    for a in assumptions:
+        with subtests.test(f"test_assumption_{a}"):
+            test(a)
+
+
 def test_db_params_lca(data):
     """Test multiLCAAlgebraic with parameters with similar names from similar DBs"""
     USER_DB2 = "fg2"

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -328,6 +328,29 @@ def test_params_user_assumptions(subtests):
             test(a)
 
 
+def test_params_infer_assumptions():
+    from lca_algebraic import newFloatParam
+
+    p1 = newFloatParam("p1", default= 1.0, min= 1.0, max= 2.0)
+    p2 = newFloatParam("p2", default=-1.0, min=-2.0, max=-1.0)
+    p3 = newFloatParam("p3", default= 1.0, min= 0.0, max= 2.0)
+    p4 = newFloatParam("p4", default=-1.0, min=-2.0, max= 0.0)
+    p5 = newFloatParam("p5", default= 1.0, min=-2.0, max= 2.0)
+
+    assert p1.is_positive is True
+    assert p1.is_zero is False
+    assert p2.is_negative is True
+    assert p2.is_zero is False
+    assert p3.is_nonnegative is True
+    assert p3.is_negative is False
+    assert p4.is_nonpositive is True
+    assert p4.is_positive is False
+    assert p5.is_real is True
+    assert p5.is_positive is None
+    assert p5.is_negative is None
+    assert p5.is_zero is None
+
+
 def test_db_params_lca(data):
     """Test multiLCAAlgebraic with parameters with similar names from similar DBs"""
     USER_DB2 = "fg2"

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -299,6 +299,29 @@ def test_params_user_assumptions(subtests):
             test(a)
 
 
+def test_params_infer_assumptions():
+    from lca_algebraic import newFloatParam
+
+    p1 = newFloatParam("p1", default= 1.0, min= 1.0, max= 2.0)
+    p2 = newFloatParam("p2", default=-1.0, min=-2.0, max=-1.0)
+    p3 = newFloatParam("p3", default= 1.0, min= 0.0, max= 2.0)
+    p4 = newFloatParam("p4", default=-1.0, min=-2.0, max= 0.0)
+    p5 = newFloatParam("p5", default= 1.0, min=-2.0, max= 2.0)
+
+    assert p1.is_positive is True
+    assert p1.is_zero is False
+    assert p2.is_negative is True
+    assert p2.is_zero is False
+    assert p3.is_nonnegative is True
+    assert p3.is_negative is False
+    assert p4.is_nonpositive is True
+    assert p4.is_positive is False
+    assert p5.is_real is True
+    assert p5.is_positive is None
+    assert p5.is_negative is None
+    assert p5.is_zero is None
+
+
 @pytest.mark.parametrize("dbname", ["simple","windows?","linux/"])
 def test_db_params_lca(dbname, data):
     """Test multiLCAAlgebraic with parameters with same names from different DBs"""

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -284,6 +284,21 @@ def test_simplify_model(data):
     assert res.expr.__repr__() == "3.0*p5 + 6.01"
 
 
+def test_params_user_assumptions(subtests):
+    from sympy.core.assumptions import _assume_defined
+    from lca_algebraic import newFloatParam
+
+    def test(a):
+        p1 = newFloatParam(f"{a}_true",  default=1.0, **{a: True})
+        p2 = newFloatParam(f"{a}_false", default=1.0, **{a: False})
+        assert p1.assumptions0[a] is True
+        assert p2.assumptions0[a] is False
+
+    for a in _assume_defined:
+        with subtests.test(f"test_assumption_{a}"):
+            test(a)
+
+
 @pytest.mark.parametrize("dbname", ["simple","windows?","linux/"])
 def test_db_params_lca(dbname, data):
     """Test multiLCAAlgebraic with parameters with same names from different DBs"""


### PR DESCRIPTION
Hello,

Currently parameters assumptions are set to real=True and user assumptions are ignored

This patch series allow user to specify it's own assumtions for a given parameter. Moreover now when the user do not provide assumptions, newFloatParam will infer assumption given min/max provided by the user.

I added corresponding test.

Note: it's always assumed that a parameter is finite value.

Best regards