### PR TITLE
Remove empty parameter entries from params

### DIFF
--- a/lca_algebraic/params.py
+++ b/lca_algebraic/params.py
@@ -962,6 +962,9 @@ class ParamRegistry:
                 if db_name in db_params:
                     del db_params[db_name]
 
+                if not db_params:
+                    del self.params[param_name]
+
     def all(self):
         """Return list of all parameters, including params with same names and different DB"""
         return list(param for params in self.params.values() for param in params.values())


### PR DESCRIPTION
Avoid error upon activity creation. Here is an exemple of a code producing such an error:

import lca_algebraic as agb

FG_DB = f"OS_database_fg"

agb.newFloatParam("p1", 1, dbname=FG_DB)
agb.params.resetParams(FG_DB)
param = agb.newFloatParam("p2", 1, dbname=FG_DB)
act = agb.newActivity(FG_DB, "a1", "unit")
agb.newActivity(FG_DB, "a2", "unit", exchanges={act:param})